### PR TITLE
Correct 'dense' data type

### DIFF
--- a/source/PathFinding.java
+++ b/source/PathFinding.java
@@ -32,7 +32,7 @@ public class PathFinding {
 	//GENERAL VARIABLES
 	private int cells = 20;
 	private int delay = 30;
-	private int dense = .5;
+	private double dense = .5;
 	private double density = (cells*cells)*.5;
 	private int startx = -1;
 	private int starty = -1;


### PR DESCRIPTION
global variable dense returns a type error. it expects an integer when it almost always needs a double.